### PR TITLE
Fixing missing input in node post

### DIFF
--- a/src/service/router.ts
+++ b/src/service/router.ts
@@ -67,7 +67,7 @@ export async function createRouter(
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify(entityMetadata),
+        body: JSON.stringify({ input: entityMetadata }),
       });
       const opaEntityCheckerResponse = await opaResponse.json();
       return res.json(opaEntityCheckerResponse);
@@ -112,7 +112,7 @@ export async function createRouter(
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify(policyInput),
+        body: JSON.stringify({ input: policyInput }),
       });
       logger.info(
         `Permission request sent to OPA with input: ${JSON.stringify(


### PR DESCRIPTION
Quick fix for an issue where `input` was missing from the node post request for the permissions and entitychecker route.